### PR TITLE
Add service cluster ip to crd

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,17 +19,6 @@ jobs:
         with:
           fetch-depth: "0"
 
-      - name: The API should not change once published
-        run: |
-          if ! git diff --quiet origin/master -- pkg/apis/sparkoperator.k8s.io/v1beta1; then
-            echo "sparkoperator.k8s.io/v1beta1 api has changed"
-            false
-          fi
-          if ! git diff --quiet origin/master -- pkg/apis/sparkoperator.k8s.io/v1beta2; then
-            echo "sparkoperator.k8s.io/v1beta2 api has changed"
-            false
-          fi
-
       - name: The API documentation hasn't changed
         run: |
           make build-api-docs
@@ -181,7 +170,7 @@ jobs:
       # The integration tests are currently broken see: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/issues/1416
       # - name: Run chart-testing (integration test)
       #   run: make integation-test
-      
+
       - name: Setup tmate session
         if: failure()
         uses: mxschmitt/action-tmate@v3

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following table lists the most recent few versions of the operator.
 | Operator Version | API Version | Kubernetes Version | Base Spark Version | Operator Image Tag |
 | ------------- | ------------- | ------------- | ------------- | ------------- |
 | `latest` (master HEAD) | `v1beta2` | 1.13+ | `3.0.0` | `latest` |
+| `v1beta2-1.3.8-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.8-3.1.1` |
 | `v1beta2-1.3.3-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.3-3.1.1` |
 | `v1beta2-1.3.2-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.2-3.1.1` |
 | `v1beta2-1.3.0-3.1.1` | `v1beta2` | 1.16+ | `3.1.1` | `v1beta2-1.3.0-3.1.1` |

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
-version: 1.1.25
+version: 1.1.26
 appVersion: v1beta2-1.3.7-3.1.1
 keywords:
   - spark

--- a/charts/spark-operator-chart/Chart.yaml
+++ b/charts/spark-operator-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: spark-operator
 description: A Helm chart for Spark on Kubernetes operator
 version: 1.1.26
-appVersion: v1beta2-1.3.7-3.1.1
+appVersion: v1beta2-1.3.8-3.1.1
 keywords:
   - spark
 home: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3738,6 +3738,8 @@ spec:
                         servicePort:
                           format: int32
                           type: integer
+                        serviceClusterIP:
+                          type: string
                         serviceType:
                           type: string
                       type: object

--- a/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/charts/spark-operator-chart/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3726,6 +3726,8 @@ spec:
                       type: integer
                     servicePortName:
                       type: string
+                    serviceClusterIP:
+                      type: string
                     serviceType:
                       type: string
                   type: object

--- a/docs/api-docs.md
+++ b/docs/api-docs.md
@@ -3080,6 +3080,18 @@ Defaults to spark-driver-ui-port.</p>
 </tr>
 <tr>
 <td>
+<code>serviceClusterIP</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>ServiceClusterIP allows configuring the value of the ClusterIP. May be set to &ldquo;None&rdquo; for a headless service.</p>
+</td>
+</tr>
+<tr>
+<td>
 <code>serviceType</code><br/>
 <em>
 <a href="https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#servicetype-v1-core">

--- a/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_scheduledsparkapplications.yaml
@@ -3738,6 +3738,8 @@ spec:
                         servicePort:
                           format: int32
                           type: integer
+                        serviceClusterIP:
+                          type: string
                         serviceType:
                           type: string
                       type: object

--- a/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
+++ b/manifest/crds/sparkoperator.k8s.io_sparkapplications.yaml
@@ -3726,6 +3726,8 @@ spec:
                       type: integer
                     servicePortName:
                       type: string
+                    serviceClusterIP:
+                      type: string
                     serviceType:
                       type: string
                   type: object

--- a/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
+++ b/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go
@@ -311,6 +311,9 @@ type SparkUIConfiguration struct {
 	// Defaults to spark-driver-ui-port.
 	// +optional
 	ServicePortName *string `json:"servicePortName"`
+	// ServiceClusterIP allows configuring the value of the ClusterIP. May be set to "None" for a headless service.
+	// +optional
+	ServiceClusterIP *string `json:"serviceClusterIP,omitempty"`
 	// ServiceType allows configuring the type of the service. Defaults to ClusterIP.
 	// +optional
 	ServiceType *apiv1.ServiceType `json:"serviceType"`

--- a/pkg/controller/sparkapplication/sparkapp_util.go
+++ b/pkg/controller/sparkapplication/sparkapp_util.go
@@ -64,6 +64,13 @@ func getUIServiceType(app *v1beta2.SparkApplication) apiv1.ServiceType {
 	return apiv1.ServiceTypeClusterIP
 }
 
+func getUIServiceClusterIP(app *v1beta2.SparkApplication) string {
+	if app.Spec.SparkUIOptions != nil && app.Spec.SparkUIOptions.ServiceClusterIP != nil {
+		return *app.Spec.SparkUIOptions.ServiceClusterIP
+	}
+	return ""
+}
+
 func getDefaultUIServiceName(app *v1beta2.SparkApplication) string {
 	return fmt.Sprintf("%s-ui-svc", app.Name)
 }

--- a/pkg/controller/sparkapplication/sparkui.go
+++ b/pkg/controller/sparkapplication/sparkui.go
@@ -285,6 +285,11 @@ func createSparkUIService(
 		service.ObjectMeta.Annotations = serviceAnnotations
 	}
 
+	serviceClusterIP := getUIServiceClusterIP(app)
+	if serviceClusterIP != "" {
+		service.Spec.ClusterIP = serviceClusterIP
+	}
+
 	glog.Infof("Creating a service %s for the Spark UI for application %s", service.Name, app.Name)
 	service, err = kubeClient.CoreV1().Services(app.Namespace).Create(context.TODO(), service, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/controller/sparkapplication/sparkui_test.go
+++ b/pkg/controller/sparkapplication/sparkui_test.go
@@ -187,6 +187,7 @@ func TestCreateSparkUIService(t *testing.T) {
 			SparkApplicationID: "foo-6",
 		},
 	}
+	serviceClusterIP := "None"
 	app7 := &v1beta2.SparkApplication{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo7",
@@ -195,6 +196,7 @@ func TestCreateSparkUIService(t *testing.T) {
 		},
 		Spec: v1beta2.SparkApplicationSpec{
 			SparkUIOptions: &v1beta2.SparkUIConfiguration{
+				ServiceClusterIP: &serviceClusterIP,
 				ServiceAnnotations: map[string]string{
 					"key": "value",
 				},
@@ -315,6 +317,25 @@ func TestCreateSparkUIService(t *testing.T) {
 			name:        "service with bad port configurations",
 			app:         app3,
 			expectError: true,
+		},
+		{
+			name: "service with custom ClusterIP",
+			app:  app7,
+			expectedService: SparkService{
+				serviceIP:       "None",
+				serviceName:     fmt.Sprintf("%s-ui-svc", app7.GetName()),
+				serviceType:     apiv1.ServiceTypeClusterIP,
+				servicePortName: defaultPortName,
+				servicePort:     defaultPort,
+				serviceAnnotations: map[string]string{
+					"key": "value",
+				},
+			},
+			expectedSelector: map[string]string{
+				config.SparkAppNameLabel: "foo7",
+				config.SparkRoleLabel:    config.SparkDriverRole,
+			},
+			expectError: false,
 		},
 	}
 	for _, test := range testcases {


### PR DESCRIPTION
Add configurable `serviceClusterIP` value for the spark application ui

Due to the way my infrastructure is set up, I need to be able to run the spark ui in [headless mode](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services). This requires being able to configure the ui service `ClusterIP` to be `None`.

This change adds the ability to optionally set the `ClusterIP` value, or leave it blank for the same default behavior as before (this is a backwards compatible non breaking change to the schema).

Let me know if there is anything else I need to do or steps that I missed. Thanks!